### PR TITLE
Fix Podaacpy issues in Intro_09_Xarray_advanced_hurricane_case_study.ipynb

### DIFF
--- a/ocean_python_tutorial/.ipynb_checkpoints/Intro_09_Xarray_advanced_hurricane_case_study-checkpoint.ipynb
+++ b/ocean_python_tutorial/.ipynb_checkpoints/Intro_09_Xarray_advanced_hurricane_case_study-checkpoint.ipynb
@@ -110,7 +110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,7 +131,7 @@
     "from podaac import drive as drive\n",
     "#note autherntication credentials are provided in the 'podaac.ini' file\n",
     "#C:\\\\Users\\\\gentemann\\\\Miniconda3\\\\envs\\\\satenv\\\\lib\\\\site-packages\\\\podaac\\\\tests\\\\podaac.ini\n",
-    "d = drive.Drive('.\\podaac.ini', None, None)"
+    "d = drive.Drive(None, 'podaacpy', 'hZHYQ17yuag25zivK8F')"
    ]
   },
   {
@@ -154,14 +154,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/227/20110815090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/228/20110816090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/229/20110817090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/230/20110818090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/231/20110819090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/232/20110820090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/233/20110821090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc']\n"
+      "['https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/227/20110815090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/228/20110816090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/229/20110817090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/230/20110818090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/231/20110819090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/232/20110820090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/233/20110821090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/234/20110822090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/235/20110823090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/236/20110824090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/237/20110825090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/238/20110826090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/239/20110827090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/240/20110828090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/241/20110829090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/242/20110830090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/243/20110831090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/244/20110901090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/245/20110902090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/246/20110903090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/247/20110904090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/248/20110905090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/249/20110906090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/250/20110907090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/251/20110908090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/252/20110909090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/253/20110910090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/254/20110911090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/255/20110912090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/256/20110913090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/257/20110914090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/258/20110915090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc']\n"
      ]
     }
    ],
    "source": [
     "#use p.dataset_search to find the dataset id for MUR SST\n",
     "#dresult = p.dataset_search(keyword='mur',start_time='2018-09-01T00:00:00Z',end_time='2018-09-30T23:59:59Z')\n",
-    "gresult = p.granule_search(dataset_id='PODAAC-GHGMR-4FJ04',start_time='2011-08-15T00:00:00Z',end_time='2011-09-15T23:59:59Z')\n",
+    "gresult = p.granule_search(dataset_id='PODAAC-GHGMR-4FJ04',start_time='2011-08-15T00:00:00Z',end_time='2011-09-15T23:59:59Z', items_per_page='50')\n",
     "#use podaac drive to find we provide a convenience function which enables easy access to all Drive urls\n",
     "urls = d.mine_drive_urls_from_granule_search(granule_search_response=gresult)\n",
     "#podaac drive requires credentials and this isn't compatible with how xarray reads in data, so let's switch to opendap dir by changing file path\n",
@@ -319,49 +319,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#dresult = p.dataset_search(keyword='ccmp',start_time='2011-08-15T00:00:00Z',end_time='2011-09-15T23:59:59Z')\n",
-    "#dresult"
+    "# dresult = p.dataset_search(keyword='ccmp',start_time='2011-08-15T00:00:00Z',end_time='2011-09-15T23:59:59Z', items_per_page='50')\n",
+    "# print(dresult)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "urls: ['https://podaac-tools.jpl.nasa.gov/drive/files/allData/ccmp/L3.0/flk/1987/07/analysis_19870702_v11l30flk.nc.gz', 'https://podaac-tools.jpl.nasa.gov/drive/files/allData/ccmp/L3.0/flk/1987/07/analysis_19870703_v11l30flk.nc.gz', 'https://podaac-tools.jpl.nasa.gov/drive/files/allData/ccmp/L3.0/flk/1987/07/analysis_19870704_v11l30flk.nc.gz', 'https://podaac-tools.jpl.nasa.gov/drive/files/allData/ccmp/L3.0/flk/1987/07/analysis_19870705_v11l30flk.nc.gz', 'https://podaac-tools.jpl.nasa.gov/drive/files/allData/ccmp/L3.0/flk/1987/07/analysis_19870706_v11l30flk.nc.gz', 'https://podaac-tools.jpl.nasa.gov/drive/files/allData/ccmp/L3.0/flk/1987/07/analysis_19870707_v11l30flk.nc.gz', 'https://podaac-tools.jpl.nasa.gov/drive/files/allData/ccmp/L3.0/flk/1987/07/analysis_19870708_v11l30flk.nc.gz']\n",
-      "['https://podaac-opendap.jpl.nasa.gov/opendap/allData/ccmp/L3.0/flk/1987/07/analysis_19870702_v11l30flk.nc.gz', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ccmp/L3.0/flk/1987/07/analysis_19870703_v11l30flk.nc.gz', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ccmp/L3.0/flk/1987/07/analysis_19870704_v11l30flk.nc.gz', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ccmp/L3.0/flk/1987/07/analysis_19870705_v11l30flk.nc.gz', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ccmp/L3.0/flk/1987/07/analysis_19870706_v11l30flk.nc.gz', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ccmp/L3.0/flk/1987/07/analysis_19870707_v11l30flk.nc.gz', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ccmp/L3.0/flk/1987/07/analysis_19870708_v11l30flk.nc.gz']\n",
-      "<xarray.Dataset>\n",
-      "Dimensions:  (lat: 628, lon: 1440, time: 4)\n",
-      "Coordinates:\n",
-      "  * lon      (lon) float32 0.125 0.375 0.625 0.875 ... 359.375 359.625 359.875\n",
-      "  * lat      (lat) float32 -78.375 -78.125 -77.875 ... 77.875 78.125 78.375\n",
-      "  * time     (time) datetime64[ns] 1987-07-02 ... 1987-07-02T18:00:00\n",
-      "Data variables:\n",
-      "    uwnd     (time, lat, lon) float32 ...\n",
-      "    vwnd     (time, lat, lon) float32 ...\n",
-      "    nobs     (time, lat, lon) float32 ...\n",
-      "Attributes:\n",
-      "    Conventions:                     COARDS\n",
-      "    title:                           Atlas FLK v1.1 derived surface winds (le...\n",
-      "    description:                     VAM 6-hour analyses starting from the EC...\n",
-      "    history:                         Created by NASA Goddard Space Flight Cen...\n",
-      "    base_date:                       [1987    7    2]\n",
-      "    DODS_EXTRA.Unlimited_Dimension:  time\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#ccmp\n",
     "#dresult = p.dataset_search(keyword='ccmp',start_time='2018-09-01T00:00:00Z',end_time='2018-09-15T23:59:59Z')\n",
-    "gresult = p.granule_search(dataset_id='PODAAC-CCF30-01XXX',start_time='2011-08-15T00:00:00Z',end_time='2011-09-15T23:59:59Z')\n",
+    "gresult = p.granule_search(dataset_id='PODAAC-CCF30-01XXX',start_time='2011-08-15T00:00:00Z',end_time='2011-09-15T23:59:59Z', items_per_page='50', sort_by='timeDesc')\n",
     "#use podaac drive to find we provide a convenience function which enables easy access to all Drive urls\n",
     "#print(gresult)\n",
     "urls = d.mine_drive_urls_from_granule_search(granule_search_response=gresult)\n",
-    "print('urls:',urls)\n",
     "urls_wnd = [w.replace('-tools.jpl.nasa.gov/drive/files/', '-opendap.jpl.nasa.gov/opendap/') for w in urls]\n",
     "print(urls_wnd)\n",
     "url = urls_wnd[0] \n",
@@ -765,7 +738,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/ocean_python_tutorial/Intro_09_Xarray_advanced_hurricane_case_study.ipynb
+++ b/ocean_python_tutorial/Intro_09_Xarray_advanced_hurricane_case_study.ipynb
@@ -110,7 +110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,7 +131,7 @@
     "from podaac import drive as drive\n",
     "#note autherntication credentials are provided in the 'podaac.ini' file\n",
     "#C:\\\\Users\\\\gentemann\\\\Miniconda3\\\\envs\\\\satenv\\\\lib\\\\site-packages\\\\podaac\\\\tests\\\\podaac.ini\n",
-    "d = drive.Drive('.\\podaac.ini', None, None)"
+    "d = drive.Drive(None, 'podaacpy', 'hZHYQ17yuag25zivK8F')"
    ]
   },
   {
@@ -154,14 +154,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/227/20110815090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/228/20110816090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/229/20110817090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/230/20110818090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/231/20110819090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/232/20110820090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/233/20110821090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc']\n"
+      "['https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/227/20110815090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/228/20110816090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/229/20110817090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/230/20110818090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/231/20110819090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/232/20110820090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/233/20110821090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/234/20110822090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/235/20110823090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/236/20110824090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/237/20110825090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/238/20110826090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/239/20110827090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/240/20110828090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/241/20110829090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/242/20110830090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/243/20110831090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/244/20110901090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/245/20110902090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/246/20110903090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/247/20110904090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/248/20110905090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/249/20110906090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/250/20110907090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/251/20110908090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/252/20110909090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/253/20110910090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/254/20110911090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/255/20110912090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/256/20110913090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/257/20110914090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2011/258/20110915090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc']\n"
      ]
     }
    ],
    "source": [
     "#use p.dataset_search to find the dataset id for MUR SST\n",
     "#dresult = p.dataset_search(keyword='mur',start_time='2018-09-01T00:00:00Z',end_time='2018-09-30T23:59:59Z')\n",
-    "gresult = p.granule_search(dataset_id='PODAAC-GHGMR-4FJ04',start_time='2011-08-15T00:00:00Z',end_time='2011-09-15T23:59:59Z')\n",
+    "gresult = p.granule_search(dataset_id='PODAAC-GHGMR-4FJ04',start_time='2011-08-15T00:00:00Z',end_time='2011-09-15T23:59:59Z', items_per_page='50')\n",
     "#use podaac drive to find we provide a convenience function which enables easy access to all Drive urls\n",
     "urls = d.mine_drive_urls_from_granule_search(granule_search_response=gresult)\n",
     "#podaac drive requires credentials and this isn't compatible with how xarray reads in data, so let's switch to opendap dir by changing file path\n",
@@ -319,49 +319,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#dresult = p.dataset_search(keyword='ccmp',start_time='2011-08-15T00:00:00Z',end_time='2011-09-15T23:59:59Z')\n",
-    "#dresult"
+    "# dresult = p.dataset_search(keyword='ccmp',start_time='2011-08-15T00:00:00Z',end_time='2011-09-15T23:59:59Z', items_per_page='50')\n",
+    "# print(dresult)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "urls: ['https://podaac-tools.jpl.nasa.gov/drive/files/allData/ccmp/L3.0/flk/1987/07/analysis_19870702_v11l30flk.nc.gz', 'https://podaac-tools.jpl.nasa.gov/drive/files/allData/ccmp/L3.0/flk/1987/07/analysis_19870703_v11l30flk.nc.gz', 'https://podaac-tools.jpl.nasa.gov/drive/files/allData/ccmp/L3.0/flk/1987/07/analysis_19870704_v11l30flk.nc.gz', 'https://podaac-tools.jpl.nasa.gov/drive/files/allData/ccmp/L3.0/flk/1987/07/analysis_19870705_v11l30flk.nc.gz', 'https://podaac-tools.jpl.nasa.gov/drive/files/allData/ccmp/L3.0/flk/1987/07/analysis_19870706_v11l30flk.nc.gz', 'https://podaac-tools.jpl.nasa.gov/drive/files/allData/ccmp/L3.0/flk/1987/07/analysis_19870707_v11l30flk.nc.gz', 'https://podaac-tools.jpl.nasa.gov/drive/files/allData/ccmp/L3.0/flk/1987/07/analysis_19870708_v11l30flk.nc.gz']\n",
-      "['https://podaac-opendap.jpl.nasa.gov/opendap/allData/ccmp/L3.0/flk/1987/07/analysis_19870702_v11l30flk.nc.gz', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ccmp/L3.0/flk/1987/07/analysis_19870703_v11l30flk.nc.gz', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ccmp/L3.0/flk/1987/07/analysis_19870704_v11l30flk.nc.gz', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ccmp/L3.0/flk/1987/07/analysis_19870705_v11l30flk.nc.gz', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ccmp/L3.0/flk/1987/07/analysis_19870706_v11l30flk.nc.gz', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ccmp/L3.0/flk/1987/07/analysis_19870707_v11l30flk.nc.gz', 'https://podaac-opendap.jpl.nasa.gov/opendap/allData/ccmp/L3.0/flk/1987/07/analysis_19870708_v11l30flk.nc.gz']\n",
-      "<xarray.Dataset>\n",
-      "Dimensions:  (lat: 628, lon: 1440, time: 4)\n",
-      "Coordinates:\n",
-      "  * lon      (lon) float32 0.125 0.375 0.625 0.875 ... 359.375 359.625 359.875\n",
-      "  * lat      (lat) float32 -78.375 -78.125 -77.875 ... 77.875 78.125 78.375\n",
-      "  * time     (time) datetime64[ns] 1987-07-02 ... 1987-07-02T18:00:00\n",
-      "Data variables:\n",
-      "    uwnd     (time, lat, lon) float32 ...\n",
-      "    vwnd     (time, lat, lon) float32 ...\n",
-      "    nobs     (time, lat, lon) float32 ...\n",
-      "Attributes:\n",
-      "    Conventions:                     COARDS\n",
-      "    title:                           Atlas FLK v1.1 derived surface winds (le...\n",
-      "    description:                     VAM 6-hour analyses starting from the EC...\n",
-      "    history:                         Created by NASA Goddard Space Flight Cen...\n",
-      "    base_date:                       [1987    7    2]\n",
-      "    DODS_EXTRA.Unlimited_Dimension:  time\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#ccmp\n",
     "#dresult = p.dataset_search(keyword='ccmp',start_time='2018-09-01T00:00:00Z',end_time='2018-09-15T23:59:59Z')\n",
-    "gresult = p.granule_search(dataset_id='PODAAC-CCF30-01XXX',start_time='2011-08-15T00:00:00Z',end_time='2011-09-15T23:59:59Z')\n",
+    "gresult = p.granule_search(dataset_id='PODAAC-CCF30-01XXX',start_time='2011-08-15T00:00:00Z',end_time='2011-09-15T23:59:59Z', items_per_page='50', sort_by='timeDesc')\n",
     "#use podaac drive to find we provide a convenience function which enables easy access to all Drive urls\n",
     "#print(gresult)\n",
     "urls = d.mine_drive_urls_from_granule_search(granule_search_response=gresult)\n",
-    "print('urls:',urls)\n",
     "urls_wnd = [w.replace('-tools.jpl.nasa.gov/drive/files/', '-opendap.jpl.nasa.gov/opendap/') for w in urls]\n",
     "print(urls_wnd)\n",
     "url = urls_wnd[0] \n",
@@ -765,7 +738,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
His @ cgentemann this issue addresses https://github.com/cgentemann/cloud_science/issues/7

Please look at the additional parameters I've added to the respective function calls.

There is a big somewhere in the granule_search in that the `start_time` temporal parameter is not being correctly interpreted and all granules from the beginning of the dataset until the `end_time` being retrieved. This is a bug and I will address it and write a unit test for this exact scenario. The workaround for the time being is to sort the granules by descending order meaning that you get the `end_time` first. In your example you only use one daily granule so this is OK.